### PR TITLE
Fix typos and spacing issues

### DIFF
--- a/pages/examples/bookshelf.html
+++ b/pages/examples/bookshelf.html
@@ -22,7 +22,7 @@ prerequisite: ["modelling_redundant_variables"]
 </p>
 
 <p>
-  Our gool is to put the sets on the shelves in such a way, that the highest we must reach for anything is minimal.
+  Our goal is to put the sets on the shelves in such a way, that the highest we must reach for anything is minimal.
   To keep order, we don't want to split up any sets, and we also want to have a 7cm gap between the highest book on a shelf and the shelf above.
   We are, however, not forced to use all of the plates, if it is not necessary.
 </p>

--- a/pages/gmpl_advanced_1.html
+++ b/pages/gmpl_advanced_1.html
@@ -198,7 +198,7 @@ prerequisite: ["gmpl_motivational"]
   Sets and parameters can be declared with the <code>set</code> and <code>param</code> keywords, respectively.
   If a set, parameter, variable has an subscript/index, the name should be followed by the following in the declaration: <code>{Setname}</code>, where <var>Setname</var> is the domain on which that set, parameter, or variable is defined.
   When using this set, variable or parameter, the index should be put within brackets after the name of the variable.
-  If there are more indeces, they should be sparated by commas both in the definition and in case of use.
+  If there are more indices, they should be separated by commas both in the definition and in case of use.
   If we want a constraint to be defined for each element of a set, a <code>{s \in Setname}</code> should be put after the name of the constraint, where <var>Setname</var> is the name of the set, and <var>s</var> is a dummy index that can be used within the constraint.
   The syntax for the sum symbol is similar, but let's see how it looks for our second model with \(p_{b,f}\) parameter:
 </p>
@@ -254,7 +254,7 @@ prerequisite: ["gmpl_motivational"]
 <pre class="border border-2 border-dark p-2" id="generic-gmpl-model">{% include sources/motivational_advanced/festival.m %}</pre>
 
 <p>
-  If we were to "run" this model with the usual <code>glspsol -m model.mod</code> command, we would receive an error message something like this: <var>Missing value for S</var>.
+  If we were to "run" this model with the usual <code>glspsol -m model.mod</code> command, we would receive an error message something like this: <var>Missing value for Bands</var>.
   That is because the data section is still missing. 
 </p>
 
@@ -301,7 +301,7 @@ prerequisite: ["gmpl_motivational"]
 <p>
   Note, that in the definition of the set Bands, the elements are given in new lines.
   This is ok, GMPL does not care about the number and type of white space characters (spaces, tabs, new lines).
-  So if our model is more readible like this, feel free to put in additional newlines or spaces.
+  So if our model is more readable like this, feel free to put in additional newlines or spaces.
   Similarly, a 1 dimensional parameter could be defined like this as well:
   <pre>param Param1:= element1 value1 element3 value3 element2 value2;</pre>
 </p>

--- a/pages/gmpl_advanced_2.html
+++ b/pages/gmpl_advanced_2.html
@@ -152,7 +152,7 @@ prerequisite: ["gmpl_advanced_1"]
   The several options we have:
   <ul>
     <li>Manually (or with an external tool) transpose the matrix in the data section.</li>
-    <li>Change the order of the indices in the declaration, and eveywhere in the model</li>
+    <li>Change the order of the indices in the declaration, and everywhere in the model</li>
     <li>put <code>(tr)</code> after <code>param p</code> and before the colon in the data section</li>
   </ul>
   I leave the decision to You, and let's move to the next parameter tweak.
@@ -173,7 +173,7 @@ prerequisite: ["gmpl_advanced_1"]
 <h2 id="measurement-units">Measurement units</h2>
 
 <p>
-  It has already be mentioned, that it is always a good practice to put measurement units in comments next to the declarations and definition to avoid <a href="http://mentalfloss.com/article/25845/quick-6-six-unit-conversion-disasters" target="_blank">catastrophies</a>.
+  It has already be mentioned, that it is always a good practice to put measurement units in comments next to the declarations and definition to avoid <a href="http://mentalfloss.com/article/25845/quick-6-six-unit-conversion-disasters" target="_blank">catastrophe</a>.
   However, it can happen that there is a parameter, that You often receive in one unit for some data files, and in another for other data files.
   You use one of them in your constraints, but You don't want to have separate model files for the two types of inputs. 
 </p>
@@ -257,8 +257,8 @@ prerequisite: ["gmpl_advanced_1"]
 
 <p>
   The other thing is the <code>for</code> structure, that is a foreach type of loop.
-  It basically goes throug all of the fröccs types with a dummy index.
-  After the colon, we can put filters, in this case we want to express that go only through thos fröccs types, that are actually produced in some quantity.
+  It basically goes through all of the fröccs types with a dummy index.
+  After the colon, we can put filters, in this case we want to express that we go only through those fröccs types, that are actually produced in some quantity.
 </p>
 
 <div class="alert alert-info">

--- a/pages/gmpl_basics.html
+++ b/pages/gmpl_basics.html
@@ -215,8 +215,8 @@ prerequisite: ["modelling_lp_first_steps"]
 <table class="table table-hover">
   <thead>
     <tr>
-      <th scope="col">Mathematical notation</th>
-      <th scope="col">GMPL code</th>
+      <th style="width:50%" scope="col">Mathematical notation</th>
+      <th style="width:50%" scope="col">GMPL code</th>
     </tr>
   </thead>
   <tbody>
@@ -254,8 +254,8 @@ prerequisite: ["modelling_lp_first_steps"]
 <table class="table table-hover">
   <thead>
     <tr>
-      <th scope="col">Mathematical notation</th>
-      <th scope="col">GMPL code</th>
+      <th style="width:50%" scope="col">Mathematical notation</th>
+      <th style="width:50%" scope="col">GMPL code</th>
     </tr>
   </thead>
   <tbody>
@@ -290,8 +290,8 @@ prerequisite: ["modelling_lp_first_steps"]
 <table class="table table-hover">
   <thead>
     <tr>
-      <th scope="col">Mathematical notation</th>
-      <th scope="col">GMPL code</th>
+      <th style="width:50%" scope="col">Mathematical notation</th>
+      <th style="width:50%" scope="col">GMPL code</th>
     </tr>
   </thead>
   <tbody>

--- a/pages/gmpl_basics.html
+++ b/pages/gmpl_basics.html
@@ -247,7 +247,7 @@ prerequisite: ["modelling_lp_first_steps"]
 
 <p>
   Constraints are written in the form of <code>s.t. CNAME: LHS OP RHS;</code> where <code>CNAME</code> is an expressive name for the constraint, <code>LHS,RHS</code> are the left- and right-hand side of the inequality/equasion respectively, separated by a comparison operator, that could be either <code><=</code>,<code>>=</code> or <code>=</code>.
-  The name of the constraint does not hold any importance to the solver, it is just an identifier, that also helps to make the code more human-readible and maintainable.
+  The name of the constraint does not hold any importance to the solver, it is just an identifier, that also helps to make the code more human-readable and maintainable.
   Also, mind the colon for separating the name and the constraint, and a semicolon closing the statement. Some examples:
 </p>
 
@@ -347,7 +347,7 @@ prerequisite: ["modelling_lp_first_steps"]
   First, the fifth line with <code>Status: OPTIMAL</code> indicates again, that everything went well, and we have found an optimal solution.
   The line below that tells us, what that optimal solution is.
   Here, the word "Objective" appears twice, which seems buggy.
-  But this is just a coincidence, as the firt appearance is burned in the solver, and the second is the name that we gave to our objective function, which happened to be "Objective" as well for this simple problem.
+  But this is just a coincidence, as the first appearance is burned in the solver, and the second is the name that we gave to our objective function, which happened to be "Objective" as well for this simple problem.
 </p>
 
 <p>

--- a/pages/gmpl_motivational.html
+++ b/pages/gmpl_motivational.html
@@ -90,7 +90,7 @@ prerequisite: ["gmpl_basics","modelling_lp_first_steps"]
 </table>
 
 <p>
-  Let's have a look at the ouptut:
+  Let's have a look at the output:
 </p>
 
 
@@ -163,7 +163,7 @@ prerequisite: ["gmpl_basics","modelling_lp_first_steps"]
 
 
 <p>
-  Again, let's have a look at the ouptut:
+  Again, let's have a look at the output:
 </p>
 
 

--- a/pages/modelling_lp_first_steps.html
+++ b/pages/modelling_lp_first_steps.html
@@ -131,8 +131,7 @@ prerequisite: ["motivational_festival","motivational_froccs"]
 
 
 <p>
-  Mathematical models that meet the above conditions are LP models, and can be solved to optimality efficiently (computational time is bounded by a polinomial function of the number of variables) by a <a href="https://en.wikipedia.org/wiki/Simplex_algorithm" target="_blank">simplex algorithm</a> variant or <a href="https://en.wikipedia.org/wiki/Interior-point_method" target = "_blank">interior point method</a>.
-  
+  Mathematical models that meet the above conditions are LP models, and can be solved to optimality efficiently (computational time is bounded by a polynomial function of the number of variables) by a <a href="https://en.wikipedia.org/wiki/Simplex_algorithm" target="_blank">simplex algorithm</a> variant or <a href="https://en.wikipedia.org/wiki/Interior-point_method" target = "_blank">interior point method</a>.
 </p>
 
 <h2 id="festival-example">Model for the <a href="{{site.baseurl}}/pages/motivational_festival.html">Festival example</a></h2>
@@ -316,7 +315,7 @@ prerequisite: ["motivational_festival","motivational_froccs"]
 
 <p>
   Note, that not all MILP models are difficult to solve.
-  If, for example, the matrix of the coefficients in the model is <a href="https://en.wikipedia.org/wiki/Unimodular_matrix#Total_unimodularity" target="_blank">totally unimodular</a>, the problem can be solved in polinomial time, just as in the case for LP problems.
+  If, for example, the matrix of the coefficients in the model is <a href="https://en.wikipedia.org/wiki/Unimodular_matrix#Total_unimodularity" target="_blank">totally unimodular</a>, the problem can be solved in polynomial time, just as in the case for LP problems.
   A famous example is the <a href="https://en.wikipedia.org/wiki/Assignment_problem" target="_blank">Assignment problem</a>, which can be solved efficiently by the <a href="https://en.wikipedia.org/wiki/Hungarian_algorithm" target="_blank">Hungarian method</a>. (The algorithm was developed by an american mathemtician, <a href="https://en.wikipedia.org/wiki/Harold_W._Kuhn" target="_blank">Harold W. Kuhn</a>, who gave this name because the algorithm was based on the former works of two Hungarian mathematicians: <a href="https://en.wikipedia.org/wiki/D%C3%A9nes_K%C5%91nig" target="_blank">Dénes Kőnig</a> and <a href="https://en.wikipedia.org/wiki/Jen%C5%91_Egerv%C3%A1ry" target="_blank">Jenő Egerváry</a>. The former is the author of the first <a href="https://books.google.hu/books?id=zQ2X8NNPL_wC&pg=PP3&source=gbs_selected_pages&cad=3#v=onepage&q&f=false" target="_blank">graph-theory textbook.</a>)
 </p>
 

--- a/pages/modelling_redundant_variables.html
+++ b/pages/modelling_redundant_variables.html
@@ -163,9 +163,9 @@ prerequisite: ["modelling_lp_first_steps","gmpl_advanced_1"]
   </pre>
 </p>
 
-<h4>The overall modell</h4>
+<h4>The overall model</h4>
 <p>
-  The overall modell looks like this:  
+  The overall model looks like this:  
 </p>
 
 <pre class="border border-2 border-dark p-2" id="africa1m">{% include sources/africa_car_ride/africa.m %}</pre>
@@ -186,7 +186,7 @@ prerequisite: ["modelling_lp_first_steps","gmpl_advanced_1"]
 <h2 id="othermodel">A different way of modelling the problem</h2>
 
 <p>
-  If an IT person would look at the above code, he/she would probably consider it a bit ugly, as the term <code>initialTank + sum {s2 in Stations: distance[s2] < distance[s]} fill[s2]</code> repeats a couple of times thourough the model.
+  If an IT person would look at the above code, he/she would probably consider it a bit ugly, as the term <code>initialTank + sum {s2 in Stations: distance[s2] < distance[s]} fill[s2]</code> repeats a couple of times through the model.
   In case of such redundancy in a computer code, the programmer would probably introduce a function, that can be called from different places.
 </p>
 
@@ -251,13 +251,13 @@ prerequisite: ["modelling_lp_first_steps","gmpl_advanced_1"]
   <ul>
     <li>Adding a few continuous variables does not really make the problem that much harder to solve.</li>
     <li>A good solver will probably realize this, and exclude them.</li>
-    <li>Some languages may support this explicitely, like defined variables in AMPL</li>
+    <li>Some languages may support this explicitly, like defined variables in AMPL</li>
     <li>Sometimes, especially for easy-to-solve problems with complicated constraints, a maintainable code is much more important.</li>
     <li>If the model gets extended, these variables may come in handy.</li>
   </ul>
 </p>
 
-<h2 id="exercise">Excercise for you</h2>
+<h2 id="exercise">Exercise for you</h2>
 <p>
   The model could be transformed a bit further as well based on the following idea: the fuel level in the tank at a station is simply the level when leaving the <emph>last</emph> station minus the fuel burned since then.
   Create a model, that calculates the <code>fuelAtArrival[s]</code> values based on this idea.


### PR DESCRIPTION
I came across your lecture notes, which are very well done and the best introduction I could find online on this subject. Thanks!

This PR fixes a few grammar typos and also fixes the width of the columns in `gmpl_basics.html` as you did in other files to resolve spacing issues with MJX allocating way too much space and thus compressing the columns in tables.
